### PR TITLE
Supress unneccessary call "dequeue snackbar"

### DIFF
--- a/src/components/Snackbars/index.tsx
+++ b/src/components/Snackbars/index.tsx
@@ -12,10 +12,12 @@ const Snackbars = () => {
   }
 
   useEffect(() => {
-    const timer = setTimeout(() => {
-      dispatch(snackbarSlice.actions.dequeue())
-    }, 5000)
-    return () => clearTimeout(timer)
+    if(currentSnackbar) {
+      const timer = setTimeout(() => {
+        dispatch(snackbarSlice.actions.dequeue())
+      }, 5000)
+      return () => clearTimeout(timer)
+    }
   }, [currentSnackbar, dispatch])
 
   if (!currentSnackbar) {


### PR DESCRIPTION
dequeue action is called, even if currentSnackbar is empty undefined